### PR TITLE
Add path to workflow

### DIFF
--- a/.github/workflows/deploy_hugo_to_s3.yaml
+++ b/.github/workflows/deploy_hugo_to_s3.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - main
+    paths:
+    - "../../website/**"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Adds a `path` to the workflow so that only changes in the `website` folder will trigger the run.