### PR TITLE
Add www version of URL as env variable

### DIFF
--- a/infra/lambda/visitor_counter/lambda_function.py
+++ b/infra/lambda/visitor_counter/lambda_function.py
@@ -9,6 +9,7 @@ from datetime import datetime
 logger = Logger()
 
 DEV_URL = os.environ["DEV_URL"]
+DEV_URL = os.environ["DEV_URL_WWW"]
 BASE_URL = os.environ["BASE_URL"]
 
 def add_visitor_to_table(current_date: str, table: str) -> None:


### PR DESCRIPTION
`www` version of website is unauthorised.

Added a `www` version of base URL for origin referencing within the lambda function.